### PR TITLE
Update build instructions to work with zig 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Bare bones "hello world" i386 kernel written in [Zig](https://ziglang.org/).
 ## Building
 
 ```
-zig build-exe hellos.zig --target-os freestanding --target-arch i386 --static  --linker-script linker.ld
+zig build-exe hellos.zig -target i386-freestanding-none --linker-script linker.ld
 ```
 
 ## Testing with qemu


### PR DESCRIPTION
This works on my machine. I couldn't find a corresponding option for `--static` but I'm guessing it links statically by default?